### PR TITLE
fix: add missing protocol in fetchUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-tiny-client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "lib/index.js",
   "repository": "https://github.com/samuelgja/elastic-tiny-client",
   "scripts": {

--- a/src/elastic-client.ts
+++ b/src/elastic-client.ts
@@ -105,7 +105,7 @@ export class ElasticClient {
           Authorization: host.Authorization,
         }
       }
-      const fetchUrl = `${host.host}${urlWithoutHost}`
+      const fetchUrl = `${host.protocol}//${host.host}${urlWithoutHost}`
 
       try {
         const response = await this.#fetch(fetchUrl, options)


### PR DESCRIPTION
## Motivation and Context (Link Related Issues Here):
Setting the hosts parameter with remote IPs that are not localhost causes `TypeError: fetch() URL is invalid - code: "ERR_INVALID_ARG_VALUE"`

## Describe Code Changes in Detail:
Add missing protocol to fetchUrl

## Was Tested With:
-

## Screenshots/Examples:
Before:
<img width="616" alt="image" src="https://github.com/samuelgja/elastic-tiny-client/assets/19567624/9aa1d98b-bea0-420c-9173-936fb2d3a764">
After:
<img width="341" alt="image" src="https://github.com/samuelgja/elastic-tiny-client/assets/19567624/336266a9-91ed-4f1e-beee-146cca1add89">

## Known Affected Areas:
Every single fetch request

## Additional Context:
-