### PR TITLE
Fix GET request

### DIFF
--- a/src/elastic-client.ts
+++ b/src/elastic-client.ts
@@ -178,7 +178,7 @@ export class ElasticClient {
   }
 
   async get<T>(params: GetRequest): Promise<Response<GetResponse<T>>> {
-    let url = `/${params.index}${params.id}`
+    let url = `/${params.index}/_doc/${params.id}`
 
     const queryParams = queryParametersGenerator(
       {


### PR DESCRIPTION
I found a bug in the GET request url format. Based on the ElasticSearch GET API it is incorrectly formatted.

It should be `<index>/_doc/<_id>`
But is `<index><_id>`